### PR TITLE
Use camelCase and JSON for POST requests

### DIFF
--- a/lib/render_api/clients/deploys.rb
+++ b/lib/render_api/clients/deploys.rb
@@ -7,7 +7,7 @@ module RenderAPI
     class Deploys < Base
       def create(service_id, clear_cache: nil)
         body = nil
-        body = { clear_cache: clear_cache } unless clear_cache.nil?
+        body = { clearCache: clear_cache } unless clear_cache.nil?
 
         endpoint.post(
           "/services/#{service_id}/deploys", body: body

--- a/lib/render_api/endpoint.rb
+++ b/lib/render_api/endpoint.rb
@@ -29,10 +29,11 @@ module RenderAPI
       HTTP
         .auth("Bearer #{api_key}")
         .headers("Accept" => "application/json")
+        .headers("Content-Type" => "application/json")
     end
 
     def request(verb, path, body: nil, params: nil)
-      Response.new http.request(verb, url_for(path), body: body, params: params)
+      Response.new http.request(verb, url_for(path), json: body, params: params)
     end
 
     def url_for(path)


### PR DESCRIPTION
Thanks for creating this gem @pat! I'm an engineer at Render and helped build our API (but don't have a lot of experience with Ruby). I'm planning to open a PR that adds support for the jobs endpoints (https://api-docs.render.com/reference/list-job), but first wanted to clean up a couple small issues in the way JSON bodies were being sent.

Separately, if you have any feedback on the API or Render in general, we'd love to hear it. You can email me at david@render.com or post at https://community.render.com/.