### PR TITLE
Add support for jobs endpoints

### DIFF
--- a/lib/render_api/client.rb
+++ b/lib/render_api/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "./clients/deploys"
+require_relative "./clients/jobs"
 require_relative "./clients/owners"
 require_relative "./clients/services"
 require_relative "./endpoint"
@@ -13,6 +14,10 @@ module RenderAPI
 
     def deploys
       @deploys ||= Clients::Deploys.new(endpoint)
+    end
+
+    def jobs
+      @jobs ||= Clients::Jobs.new(endpoint)
     end
 
     def owners

--- a/lib/render_api/clients/jobs.rb
+++ b/lib/render_api/clients/jobs.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+
+module RenderAPI
+  module Clients
+    class Jobs < Base
+      def create(service_id, start_command:, plan_id: nil)
+        body = { startCommand: start_command }
+        body[:planId] = plan_id unless plan_id.nil?
+
+        endpoint.post(
+          "/services/#{service_id}/jobs", body: body
+        )
+      end
+
+      def find(service_id, job_id)
+        endpoint.get(
+          "/services/#{service_id}/jobs/#{job_id}"
+        )
+      end
+
+      def list(service_id, ...)
+        endpoint.get(
+          "/services/#{service_id}/jobs", params: list_parameters(...)
+        )
+      end
+    end
+  end
+end

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe "Jobs" do
+  let(:client) { RenderAPI.client "test-api-key" }
+  let(:service_id) { "random-string" }
+
+  subject { client.jobs }
+
+  describe "create" do
+    before :each do
+      stub_request(
+        :post, "https://api.render.com/v1/services/#{service_id}/jobs"
+      ).to_return_json(
+        body: {
+          "id" => "new-job",
+          "serviceId" => "my-service",
+          "startCommand" => "whoami",
+          "planId" => "my-plan",
+          "status" => "succeeded",
+          "finishedAt" => "2021-12-12T08:34:38.327Z",
+          "createdAt" => "2021-12-12T08:34:38.327Z",
+          "startedAt" => "2021-12-12T08:34:38.327Z"
+        }
+      )
+    end
+
+    it "returns the new job details" do
+      response = subject.create(service_id, start_command: "whoami")
+
+      expect(response.id).to eq("new-job")
+    end
+
+    it "parses timestamps" do
+      expect(
+        subject.create(service_id, start_command: "whoami").finished_at
+      ).to eq(
+        Time.utc(2021, 12, 12, 8, 34, 38, 327_000)
+      )
+    end
+  end
+
+  describe "find" do
+    let(:id) { "my-job" }
+
+    before :each do
+      stub_request(
+        :get, "https://api.render.com/v1/services/#{service_id}/jobs/#{id}"
+      ).to_return_json(
+        body: {
+          "id" => "my-job",
+          "serviceId" => "my-service",
+          "startCommand" => "whoami",
+          "planId" => "my-plan",
+          "status" => "succeeded",
+          "finishedAt" => "2021-12-12T08:34:38.327Z",
+          "createdAt" => "2021-12-12T08:34:38.327Z",
+          "startedAt" => "2021-12-12T08:34:38.327Z"
+        }
+      )
+    end
+
+    it "returns job data" do
+      response = subject.find(service_id, id)
+
+      expect(response.id).to eq(id)
+    end
+  end
+
+  describe "list" do
+    before :each do
+      stub_request(
+        :get, "https://api.render.com/v1/services/#{service_id}/jobs"
+      ).to_return_json(
+        body: [
+          {
+            "job" => {
+              "id" => "my-job",
+              "serviceId" => "my-service",
+              "startCommand" => "whoami",
+              "planId" => "my-plan",
+              "status" => "succeeded",
+              "finishedAt" => "2021-12-12T08:34:38.327Z",
+              "createdAt" => "2021-12-12T08:34:38.327Z",
+              "startedAt" => "2021-12-12T08:34:38.327Z"
+            },
+            "cursor" => "the-cursor"
+          }
+        ]
+      )
+    end
+
+    it "returns job data" do
+      response = subject.list(service_id)
+
+      expect(response.length).to eq(1)
+      expect(response.first.id).to eq("my-job")
+    end
+
+    it "returns the cursor" do
+      expect(subject.list(service_id).first.cursor).to eq("the-cursor")
+    end
+  end
+end


### PR DESCRIPTION
This is mostly modeled after the deploy endpoints, with the difference that the POST request for jobs has a required field (the start command).